### PR TITLE
Add Atari (ATASCII) Support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ endif
 
 qodem_SOURCES = \
 source/ansi.c \
+source/atari.c \
 source/avatar.c \
 source/codepage.c \
 source/colors.c \

--- a/build/Makefile.bcc5
+++ b/build/Makefile.bcc5
@@ -87,6 +87,7 @@ LDLIBS = $(QODEM_LIB_DIR)\pdcurses.lib $(QODEM_LIB_DIR)\libc.lib c:\bc5\lib\ws2_
 
 QODEM_SRC = \
 $(QODEM_SRC_DIR)/ansi.c \
+$(QODEM_SRC_DIR)/atari.c \
 $(QODEM_SRC_DIR)/avatar.c \
 $(QODEM_SRC_DIR)/codepage.c \
 $(QODEM_SRC_DIR)/colors.c \

--- a/build/Makefile.generic
+++ b/build/Makefile.generic
@@ -122,6 +122,7 @@ $(QODEM_BIN_DIR): $(QODEM_OBJS_DIR)
 
 QODEM_SRC = \
 $(QODEM_SRC_DIR)/ansi.c \
+$(QODEM_SRC_DIR)/atari.c \
 $(QODEM_SRC_DIR)/avatar.c \
 $(QODEM_SRC_DIR)/codepage.c \
 $(QODEM_SRC_DIR)/colors.c \

--- a/source/atari.c
+++ b/source/atari.c
@@ -1,0 +1,266 @@
+/*
+ * atari.c
+ *
+ * qodem - Qodem Terminal Emulator
+ *
+ * Written 2003-2016 by Kevin Lamonte
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+#include "common.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include "qodem.h"
+#include "scrollback.h"
+#include "screen.h"
+#include "atari.h"
+
+/* Set this to a not-NULL value to enable debug log. */
+/* static const char * DLOGNAME = "atari"; */
+static const char *DLOGNAME = NULL;
+extern FILE *dlogfile;
+
+static Q_BOOL last_char_esc = Q_FALSE;
+static int *tab_stops = NULL;
+static unsigned int n_tab_stops = 0;
+
+/**
+ * Advance the cursor to the next tab stop.
+ */
+static void advance_to_next_tab_stop(void) {
+    int i;
+    if (!tab_stops) goto no_tab;
+
+    for (i = 0; i < n_tab_stops; i++) {
+        if (tab_stops[i] > q_status.cursor_x) {
+            cursor_right(tab_stops[i] - q_status.cursor_x, Q_FALSE);
+            return;
+        }
+    }
+
+    /*
+     * If we got here then there isn't a tab stop beyond the current cursor
+     * position.  Place the cursor of the right-most edge of the screen.
+     */
+no_tab:
+    cursor_right(WIDTH - 1 - q_status.cursor_x, Q_FALSE);
+}
+
+/**
+ * Set a tab stop at the current position
+ */
+static void set_tab_stop(void)
+{
+    int i;
+
+    for (i = 0; i < n_tab_stops; i++) {
+        if (tab_stops[i] == q_status.cursor_x) {
+            /* Already have a tab stop here */
+            return;
+        }
+
+        if (tab_stops[i] > q_status.cursor_x) {
+            /* Insert a tab stop */
+            tab_stops = (int *)Xrealloc(tab_stops,
+                (n_tab_stops + 1) * sizeof(int), __FILE__, __LINE__);
+            memmove(&tab_stops[i + 1], &tab_stops[i],
+                (n_tab_stops - i) * sizeof(int));
+            n_tab_stops++;
+            tab_stops[i] = q_status.cursor_x;
+            return;
+        }
+    }
+
+    /* If we get here, we need to append a tab stop to the end of the array */
+    tab_stops = (int *)Xrealloc(tab_stops,
+        (n_tab_stops + 1) * sizeof(int), __FILE__, __LINE__);
+    tab_stops[n_tab_stops] = q_status.cursor_x;
+    n_tab_stops++;
+}
+
+/**
+ * Remove a tab stop at the current position
+ */
+static void clear_tab_stop(void)
+{
+    int i;
+
+    for (i = 0; i < n_tab_stops; i++) {
+        if (tab_stops[i] != q_status.cursor_x) continue;
+
+        /* Clear this tab stop */
+        memmove(tab_stops + i, tab_stops + i + 1,
+                (n_tab_stops - i) * sizeof(int));
+        n_tab_stops--;
+        return;
+    }
+}
+
+/**
+ * Push one byte through the Atari emulator.
+ *
+ * @param from_modem one byte from the remote side.
+ * @param to_screen if the return is Q_EMUL_FSM_ONE_CHAR or
+ * Q_EMUL_FSM_MANY_CHARS, then to_screen will have a character to display on
+ * the screen.
+ * @return one of the Q_EMULATION_STATUS constants.  See emulation.h.
+ */
+Q_EMULATION_STATUS atari(const unsigned char from_modem, wchar_t * to_screen) {
+    Q_BOOL handled = Q_FALSE;
+
+    /**
+     * ESC is used to toggle between printing and interpreting control
+     * characters.
+     */
+    if (!last_char_esc) {
+        handled = Q_TRUE;
+        switch (from_modem) {
+            case 27: /* ESC */
+                last_char_esc = Q_TRUE;
+                break;
+            case 28: /* Cursor Up    (CTRL + -) */
+                cursor_up(1, Q_TRUE);
+                break;
+            case 29: /* Cursor Down  (CTRL + =) */
+                cursor_down(1, Q_TRUE);
+                break;
+            case 30: /* Cursor Left  (CTRL + +) */
+                cursor_left(1, Q_TRUE);
+                break;
+            case 31: /* Cursor Right (CTRL + *) */
+                cursor_right(1, Q_TRUE);
+                break;
+            case 125: /* Clear Screen (CTRL + < or SHIFT + <) */
+                erase_screen(0, 0, HEIGHT - STATUS_HEIGHT - 1, WIDTH - 1, Q_FALSE);
+                cursor_position(0, 0);
+                break;
+            case 126: /* Backspace */
+                cursor_left(1, Q_TRUE);
+                delete_character(1);
+                break;
+            case 127: /* Tab */
+                advance_to_next_tab_stop();
+                break;
+            case 155: /* Return */
+                cursor_carriage_return();
+                if (!q_status.line_feed_on_cr)
+                    cursor_linefeed(Q_FALSE);
+                break;
+            case 156: /* Delete Line (SHIFT + Backspace) */
+                erase_line(q_status.cursor_x, WIDTH - 1, Q_FALSE);
+                break;
+            case 157: /* Insert Line (SHIFT + >) */
+                if ((q_status.cursor_y >= q_status.scroll_region_top) &&
+                    (q_status.cursor_y <= q_status.scroll_region_bottom)) {
+                    scrolling_region_scroll_down(q_status.cursor_y,
+                                                 q_status.scroll_region_bottom, 1);
+                }
+                break;
+            case 158: /* Clear Tabstop (CTRL + Tab) */
+                clear_tab_stop();
+                break;
+            case 159: /* Set Tabstop (SHIFT + Tab) */
+                set_tab_stop();
+                break;
+            case 253: /* Bell (CTRL + 2) */
+                screen_beep();
+                break;
+            case 254: /* Delete (CTRL + Backspace) */
+                delete_character(1);
+                break;
+            case 255: /* Insert (CTRL + >) */
+                insert_blanks(1);
+                break;
+            default:
+                handled = Q_FALSE;
+        }
+    }
+
+    /* If it was a control char, we've handled it */
+    if (handled) return Q_EMUL_FSM_NO_CHAR_YET;
+
+    /* Otherwise we can draw a char */
+    q_current_color &= ~Q_A_REVERSE;
+    if (from_modem & 0x80) q_current_color |= Q_A_REVERSE;
+    *to_screen = codepage_map_char(from_modem);
+    last_char_esc = Q_FALSE;
+    return Q_EMUL_FSM_ONE_CHAR;
+}
+
+/**
+ * Reset the emulation state.
+ */
+void atari_reset(void) {
+    int i;
+
+    if (tab_stops) {
+        Xfree(tab_stops, __FILE__, __LINE__);
+        tab_stops = NULL;
+        n_tab_stops = 0;
+    }
+
+    for (i = 0; (i * 8) < WIDTH; i++) {
+        tab_stops = (int *) Xrealloc(tab_stops,
+            (n_tab_stops + 1) * sizeof(int), __FILE__, __LINE__);
+        tab_stops[i] = i * 8;
+        n_tab_stops++;
+    }
+}
+
+/**
+ * Generate a sequence of bytes to send to the remote side that correspond to
+ * a keystroke.
+ *
+ * @param keystroke one of the Q_KEY values, OR a Unicode code point.  See
+ * input.h.
+ * @return a wide string that is appropriate to send to the remote side.
+ * Note that this emulation is 7-bit: only the bottom 7/8 bits are
+ * transmitted to the remote side.  See post_keystroke().
+ */
+wchar_t * atari_keystroke(const int keystroke) {
+    switch (keystroke) {
+        case Q_KEY_BACKSPACE:
+            return L"\176";
+        case Q_KEY_UP:
+            return L"\034";
+        case Q_KEY_DOWN:
+            return L"\035";
+        case Q_KEY_LEFT:
+            return L"\036";
+        case Q_KEY_RIGHT:
+            return L"\037";
+        case Q_KEY_DC:
+            return L"\376";
+        case Q_KEY_IC:
+            return L"\377";
+        case Q_KEY_DL:
+            return L"\234";
+        case Q_KEY_IL:
+            return L"\235";
+        case Q_KEY_PAD_ENTER:
+        case Q_KEY_ENTER:
+            return L"\233";
+        case Q_KEY_CTAB:
+            return L"\236";
+        case Q_KEY_STAB:
+            return L"\237";
+        case Q_KEY_CLEAR:
+            return L"\175";
+        case '\t':
+            return L"\177";
+    default:
+            break;
+    }
+
+    return NULL;
+}
+

--- a/source/atari.h
+++ b/source/atari.h
@@ -1,0 +1,68 @@
+/*
+ * atari.h
+ *
+ * qodem - Qodem Terminal Emulator
+ *
+ * Written 2003-2016 by Kevin Lamonte
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+#ifndef __ATARI_H__
+#define __ATARI_H__
+
+/* Includes --------------------------------------------------------------- */
+
+#include "emulation.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Defines ---------------------------------------------------------------- */
+
+/* Globals ---------------------------------------------------------------- */
+
+/* Functions -------------------------------------------------------------- */
+
+/**
+ * Push one byte through the Atari emulator.
+ *
+ * @param from_modem one byte from the remote side.
+ * @param to_screen if the return is Q_EMUL_FSM_ONE_CHAR or
+ * Q_EMUL_FSM_MANY_CHARS, then to_screen will have a character to display on
+ * the screen.
+ * @return one of the Q_EMULATION_STATUS constants.  See emulation.h.
+ */
+extern Q_EMULATION_STATUS atari(const unsigned char from_modem,
+                                wchar_t * to_screen);
+
+/**
+ * Reset the emulation state.
+ */
+extern void atari_reset(void);
+
+/**
+ * Generate a sequence of bytes to send to the remote side that correspond to
+ * a keystroke.
+ *
+ * @param keystroke one of the Q_KEY values, OR a Unicode code point.  See
+ * input.h.
+ * @return a wide string that is appropriate to send to the remote side.
+ * Note that this emulation is 7-bit: only the bottom 7/8 bits are
+ * transmitted to the remote side.  See post_keystroke().
+ */
+extern wchar_t * atari_keystroke(const int keystroke);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __ATARI_H__ */
+

--- a/source/codepage.c
+++ b/source/codepage.c
@@ -73,6 +73,8 @@ char * codepage_string(Q_CODEPAGE codepage) {
         return "KOI8_R";
     case Q_CODEPAGE_KOI8_U:
         return "KOI8_U";
+    case Q_CODEPAGE_ATASCII:
+        return "ATASCII";
     }
 
     /*
@@ -124,6 +126,7 @@ Q_CODEPAGE codepage_from_string(const char * string) {
     MATCH_CODEPAGE(KOI8_U, "KOI8_U");
     MATCH_CODEPAGE(KOI8_R, "KOI8-R");
     MATCH_CODEPAGE(KOI8_U, "KOI8-U");
+    MATCH_CODEPAGE(ATASCII, "ATASCII");
     return Q_CODEPAGE_DEC;
 }
 
@@ -258,6 +261,7 @@ void codepage_keyboard_handler(const int keystroke, const int flags) {
     Q_BOOL codepage_cp1252 = Q_FALSE;
     Q_BOOL codepage_koi8_r = Q_FALSE;
     Q_BOOL codepage_koi8_u = Q_FALSE;
+    Q_BOOL codepage_atascii = Q_FALSE;
 
     /*
      * Default to CP437
@@ -301,6 +305,9 @@ void codepage_keyboard_handler(const int keystroke, const int flags) {
         codepage_cp1252 = Q_TRUE;
         codepage_koi8_r = Q_TRUE;
         codepage_koi8_u = Q_TRUE;
+        break;
+    case Q_EMUL_ATARI:
+        codepage_atascii = Q_TRUE;
         break;
     }
 
@@ -457,6 +464,14 @@ void codepage_keyboard_handler(const int keystroke, const int flags) {
             return;
         }
         break;
+    case 'T':
+    case 't':
+        if (codepage_atascii == Q_TRUE) {
+            new_codepage = Q_CODEPAGE_ATASCII;
+        } else {
+            return;
+        }
+        break;
 
     case Q_KEY_F(1):
         launch_help(Q_HELP_CODEPAGE);
@@ -511,7 +526,7 @@ void codepage_refresh() {
     int message_left;
     int window_left;
     int window_top;
-    int window_height = 25;
+    int window_height = 26;
     int window_length;
     int i;
     Q_BOOL codepage_cp437 = Q_FALSE;
@@ -533,6 +548,7 @@ void codepage_refresh() {
     Q_BOOL codepage_cp1252 = Q_FALSE;
     Q_BOOL codepage_koi8_r = Q_FALSE;
     Q_BOOL codepage_koi8_u = Q_FALSE;
+    Q_BOOL codepage_atascii = Q_FALSE;
 
     if (q_screen_dirty == Q_FALSE) {
         return;
@@ -579,6 +595,9 @@ void codepage_refresh() {
         codepage_cp1252 = Q_TRUE;
         codepage_koi8_r = Q_TRUE;
         codepage_koi8_u = Q_TRUE;
+        break;
+    case Q_EMUL_ATARI:
+        codepage_atascii = Q_TRUE;
         break;
     }
 
@@ -821,6 +840,16 @@ void codepage_refresh() {
                                 Q_COLOR_MENU_COMMAND_UNAVAILABLE);
     }
     screen_put_color_printf(Q_COLOR_MENU_TEXT, _("  KOI8-U (Ukrainian)"));
+    i++;
+
+    if (codepage_atascii == Q_TRUE) {
+        screen_put_color_str_yx(window_top + i, window_left + 2, "T",
+                                Q_COLOR_MENU_COMMAND);
+    } else {
+        screen_put_color_str_yx(window_top + i, window_left + 2, "T",
+                                Q_COLOR_MENU_COMMAND_UNAVAILABLE);
+    }
+    screen_put_color_printf(Q_COLOR_MENU_TEXT, _("  ATASCII (Atari)"));
     i++;
 
     /*
@@ -1941,6 +1970,28 @@ static wchar_t koi8_u_chars[256] = {
 };
 
 /**
+ * ATASCII (Atari)
+ */
+static wchar_t atascii_chars[128] = {
+    0x2665, 0x251C, 0x23B9, 0x2518, 0x2524, 0x2510, 0x2571, 0x2572,
+    0x25E2, 0x2597, 0x25E3, 0x259D, 0x2598, 0x23BA, 0x23BD, 0x2596,
+    0x2663, 0x250C, 0x2500, 0x253C, 0x25CF, 0x2584, 0x23B8, 0x252C,
+    0x2534, 0x258C, 0x2514, 0x241B, 0x2191, 0x2193, 0x2190, 0x2192,
+    0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025, 0x0026, 0x0027,
+    0x0028, 0x0029, 0x002A, 0x002B, 0x002C, 0x002D, 0x002E, 0x002F,
+    0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037,
+    0x0038, 0x0039, 0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F,
+    0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047,
+    0x0048, 0x0049, 0x004A, 0x004B, 0x004C, 0x004D, 0x004E, 0x004F,
+    0x0050, 0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057,
+    0x0058, 0x0059, 0x005A, 0x005B, 0x005C, 0x005D, 0x005E, 0x005F,
+    0x2666, 0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067,
+    0x0068, 0x0069, 0x006A, 0x006B, 0x006C, 0x006D, 0x006E, 0x006F,
+    0x0070, 0x0071, 0x0072, 0x0073, 0x0074, 0x0075, 0x0076, 0x0077,
+    0x0078, 0x0079, 0x007A, 0x2660, 0x007C, 0x2196, 0x25C0, 0x25B6
+};
+
+/**
  * Map a character in q_current_codepage's character set to its equivalent
  * Unicode code point / glyph.
  *
@@ -1995,6 +2046,8 @@ wchar_t codepage_map_char(const unsigned char ch) {
         return koi8_r_chars[ch];
     case Q_CODEPAGE_KOI8_U:
         return koi8_u_chars[ch];
+    case Q_CODEPAGE_ATASCII:
+        return atascii_chars[ch & 0x7f];
     }
 
     /*
@@ -2166,6 +2219,14 @@ extern wchar_t codepage_unmap_byte(const wchar_t ch, const Q_CODEPAGE codepage,
     case Q_CODEPAGE_KOI8_U:
         for (i = 0; i < 255; i++) {
             if (koi8_u_chars[i] == ch) {
+                *success = Q_TRUE;
+                return i;
+            }
+        }
+        return 0;
+    case Q_CODEPAGE_ATASCII:
+        for (i = 0; i < 128; i++) {
+            if (atascii_chars[i] == ch) {
                 *success = Q_TRUE;
                 return i;
             }

--- a/source/codepage.h
+++ b/source/codepage.h
@@ -37,6 +37,7 @@ extern "C" {
 #define C_STX   0x02
 #define C_EOT   0x04
 #define C_ACK   0x06
+#define C_BS    0x08
 #define C_LF    0x0A
 #define C_CR    0x0D
 #define C_XON   0x11            /* DC1 */

--- a/source/codepage.h
+++ b/source/codepage.h
@@ -206,9 +206,9 @@ typedef enum Q_CODEPAGES {
      */
     Q_CODEPAGE_KOI8_R,          /* Russian */
     Q_CODEPAGE_KOI8_U,          /* Ukrainian */
-
+    Q_CODEPAGE_ATASCII,         /* ATASCII (Atari) */
+    Q_CODEPAGE_MAX
 } Q_CODEPAGE;
-#define Q_CODEPAGE_MAX (Q_CODEPAGE_KOI8_U + 1)
 
 #define UTF8_ACCEPT 0
 #define UTF8_REJECT 1

--- a/source/console.c
+++ b/source/console.c
@@ -999,7 +999,7 @@ void console_keyboard_handler(int keystroke, int flags) {
                     _(" Y-Exit Qodem   N-Return to TERMINAL Mode "),
                     Q_TRUE, 0.0, "YyNn\r"));
 
-            if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+            if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                 switch_state(Q_STATE_EXIT);
                 return;
             }
@@ -1259,7 +1259,7 @@ void console_keyboard_handler(int keystroke, int flags) {
                 } else {
                     new_keystroke = 'y';
                 }
-                if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+                if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                     notify_form(_("Sending Hang-Up command"), 1.5);
                     hangup_modem();
                     if (close_serial_port() == Q_FALSE) {
@@ -1499,7 +1499,7 @@ void console_keyboard_handler(int keystroke, int flags) {
                 } else {
                     new_keystroke = 'y';
                 }
-                if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+                if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                     if (Q_SERIAL_OPEN) {
                         notify_form(_("Sending Hang-Up Command"), 1.5);
                         qlog(_("Sending Hang-up Command\n"));
@@ -1708,7 +1708,7 @@ void console_keyboard_handler(int keystroke, int flags) {
                                      _(" Overwrite File? [Y/n] "),
                                      _(" Y-Overwrite Script File   N-Abort Quicklearn "),
                                      Q_TRUE, 0.0, "YyNn\r"));
-                        if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+                        if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                             start_quicklearn(filename);
                         }
                     } else {
@@ -1877,7 +1877,7 @@ void console_keyboard_handler(int keystroke, int flags) {
                     _(" Y-Exit Qodem   N-Return to TERMINAL Mode "),
                     Q_TRUE, 0.0, "YyNn\r"));
 
-            if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+            if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                 switch_state(Q_STATE_EXIT);
             }
             return;
@@ -2023,7 +2023,7 @@ void console_keyboard_handler(int keystroke, int flags) {
     /*
      * Split screen: save character UNLESS it's an ENTER
      */
-    if ((keystroke == Q_KEY_ENTER) || (keystroke == C_CR)) {
+    if ((keystroke == Q_KEY_ENTER)) {
         /*
          * Transmit entire buffer
          */
@@ -2032,7 +2032,7 @@ void console_keyboard_handler(int keystroke, int flags) {
                 (i + 1 < split_screen_buffer_n) &&
                 (split_screen_buffer[i + 1] == 'M')
             ) {
-                post_keystroke(C_CR, 0);
+                post_keystroke(Q_KEY_ENTER, 0);
                 i++;
                 continue;
             }

--- a/source/emulation.c
+++ b/source/emulation.c
@@ -28,6 +28,7 @@
 #include "vt52.h"
 #include "vt100.h"
 #include "avatar.h"
+#include "atari.h"
 #include "keyboard.h"
 #include "states.h"
 #include "options.h"
@@ -72,11 +73,12 @@ int q_emul_repeat_state_count;
  * @return Q_EMUL_TTY, Q_EMUL_VT100, etc.
  */
 Q_EMULATION emulation_from_string(const char * string) {
-
     if (strncasecmp(string, "TTY", sizeof("TTY")) == 0) {
         return Q_EMUL_TTY;
     } else if (strncasecmp(string, "ANSI", sizeof("ANSI")) == 0) {
         return Q_EMUL_ANSI;
+    } else if (strncasecmp(string, "ATARI", sizeof("ATARI")) == 0) {
+        return Q_EMUL_ATARI;
     } else if (strncasecmp(string, "AVATAR", sizeof("AVATAR")) == 0) {
         return Q_EMUL_AVATAR;
     } else if (strncasecmp(string, "VT52", sizeof("VT52")) == 0) {
@@ -116,6 +118,9 @@ const char * emulation_string(const Q_EMULATION emulation) {
 
     case Q_EMUL_ANSI:
         return "ANSI";
+
+    case Q_EMUL_ATARI:
+        return "ATARI";
 
     case Q_EMUL_AVATAR:
         return "AVATAR";
@@ -166,6 +171,8 @@ const char * emulation_term(Q_EMULATION emulation) {
     switch (emulation) {
     case Q_EMUL_ANSI:
         return "ansi";
+    case Q_EMUL_ATARI:
+        return "atari";
     case Q_EMUL_AVATAR:
         return "avatar";
     case Q_EMUL_VT52:
@@ -334,6 +341,8 @@ Q_CODEPAGE default_codepage(Q_EMULATION emulation) {
     case Q_EMUL_LINUX:
     case Q_EMUL_XTERM:
         return Q_CODEPAGE_CP437;
+    case Q_EMUL_ATARI:
+        return Q_CODEPAGE_ATASCII;
     }
 
     /*
@@ -853,6 +862,7 @@ Q_EMULATION_STATUS terminal_emulator(const unsigned char from_modem,
         (q_status.emulation != Q_EMUL_XTERM) &&
         (q_status.emulation != Q_EMUL_XTERM_UTF8) &&
         (q_status.emulation != Q_EMUL_AVATAR) &&
+        (q_status.emulation != Q_EMUL_ATARI) &&
         (q_status.emulation != Q_EMUL_DEBUG)
         ) {
         if (from_modem == C_CR) {
@@ -872,6 +882,9 @@ Q_EMULATION_STATUS terminal_emulator(const unsigned char from_modem,
     switch (q_status.emulation) {
     case Q_EMUL_ANSI:
         last_state = ansi(from_modem, to_screen);
+        break;
+    case Q_EMUL_ATARI:
+        last_state = atari(from_modem, to_screen);
         break;
     case Q_EMUL_VT52:
         last_state = vt52(from_modem, to_screen);
@@ -903,6 +916,9 @@ Q_EMULATION_STATUS terminal_emulator(const unsigned char from_modem,
             switch (q_status.emulation) {
             case Q_EMUL_ANSI:
                 last_state = ansi(q_emul_repeat_state_buffer[i], to_screen);
+                break;
+            case Q_EMUL_ATARI:
+                last_state = atari(q_emul_repeat_state_buffer[i], to_screen);
                 break;
             case Q_EMUL_VT52:
                 last_state = vt52(q_emul_repeat_state_buffer[i], to_screen);
@@ -970,6 +986,7 @@ void reset_emulation() {
      * Reset ALL of the emulators
      */
     ansi_reset();
+    atari_reset();
     vt52_reset();
     avatar_reset();
     vt100_reset();
@@ -999,6 +1016,7 @@ void reset_emulation() {
         break;
 
     case Q_EMUL_ANSI:
+    case Q_EMUL_ATARI:
     case Q_EMUL_AVATAR:
     case Q_EMUL_VT52:
     case Q_EMUL_VT100:
@@ -1020,7 +1038,7 @@ void emulation_menu_refresh() {
     int message_left;
     int window_left;
     int window_top;
-    int window_height = 18;
+    int window_height = 19;
     int window_length;
 
     if (q_screen_dirty == Q_FALSE) {
@@ -1094,7 +1112,7 @@ void emulation_menu_refresh() {
      * Add the "F1 Help" part
      */
     screen_put_color_str_yx(window_top + window_height - 1,
-                            window_left + window_length - 10, _("F1 Help"),
+                            window_left + window_length - 9, _("F1 Help"),
                             Q_COLOR_WINDOW_BORDER);
 
     screen_put_color_str_yx(window_top + 1, window_left + 2, _("Emulation is "),
@@ -1123,26 +1141,29 @@ void emulation_menu_refresh() {
     screen_put_color_str_yx(window_top + 9, window_left + 7, "G",
                             Q_COLOR_MENU_COMMAND);
     screen_put_color_printf(Q_COLOR_MENU_TEXT, "  VT220");
-    screen_put_color_str_yx(window_top + 10, window_left + 7, "L",
+    screen_put_color_str_yx(window_top + 10, window_left + 7, "H",
+                            Q_COLOR_MENU_COMMAND);
+    screen_put_color_printf(Q_COLOR_MENU_TEXT, "  ATARI");
+    screen_put_color_str_yx(window_top + 11, window_left + 7, "L",
                             Q_COLOR_MENU_COMMAND);
     screen_put_color_printf(Q_COLOR_MENU_TEXT, "  LINUX");
-    screen_put_color_str_yx(window_top + 11, window_left + 7, "T",
+    screen_put_color_str_yx(window_top + 12, window_left + 7, "T",
                             Q_COLOR_MENU_COMMAND);
     screen_put_color_printf(Q_COLOR_MENU_TEXT, "  LINUX UTF-8");
-    screen_put_color_str_yx(window_top + 12, window_left + 7, "X",
+    screen_put_color_str_yx(window_top + 13, window_left + 7, "X",
                             Q_COLOR_MENU_COMMAND);
     screen_put_color_printf(Q_COLOR_MENU_TEXT, "  XTERM");
-    screen_put_color_str_yx(window_top + 13, window_left + 7, "8",
+    screen_put_color_str_yx(window_top + 14, window_left + 7, "8",
                             Q_COLOR_MENU_COMMAND);
     screen_put_color_printf(Q_COLOR_MENU_TEXT, "  XTERM UTF-8");
-    screen_put_color_str_yx(window_top + 14, window_left + 7, "U",
+    screen_put_color_str_yx(window_top + 15, window_left + 7, "U",
                             Q_COLOR_MENU_COMMAND);
     screen_put_color_printf(Q_COLOR_MENU_TEXT, "  DEBUG");
 
     /*
      * Prompt
      */
-    screen_put_color_str_yx(window_top + 16, window_left + 2,
+    screen_put_color_str_yx(window_top + 17, window_left + 2,
                             _("Your Choice ? "), Q_COLOR_MENU_COMMAND);
 
     screen_flush();
@@ -1197,6 +1218,11 @@ void emulation_menu_keyboard_handler(const int keystroke, const int flags) {
     case 'G':
     case 'g':
         new_emulation = Q_EMUL_VT220;
+        break;
+
+    case 'H':
+    case 'h':
+        new_emulation = Q_EMUL_ATARI;
         break;
 
     case 'L':

--- a/source/emulation.h
+++ b/source/emulation.h
@@ -43,9 +43,10 @@ typedef enum Q_EMULATIONS {
     Q_EMUL_LINUX,               /* Linux console */
     Q_EMUL_LINUX_UTF8,          /* Linux console (UTF-8) */
     Q_EMUL_XTERM,               /* Xterm */
-    Q_EMUL_XTERM_UTF8           /* Xterm (UTF-8) */
+    Q_EMUL_XTERM_UTF8,          /* Xterm (UTF-8) */
+    Q_EMUL_ATARI,               /* Atari (ATASCII) */
+    Q_EMULATION_MAX
 } Q_EMULATION;
-#define Q_EMULATION_MAX (Q_EMUL_XTERM_UTF8 + 1)
 
 /**
  * The available return values from terminal_emulator().

--- a/source/forms.c
+++ b/source/forms.c
@@ -285,7 +285,6 @@ Q_BOOL prompt_listen_port(char ** port) {
             break;
 #endif
         case Q_KEY_ENTER:
-        case C_CR:
             if (field_visible == Q_TRUE) {
                 /*
                  * The OK exit point
@@ -661,7 +660,6 @@ wchar_t * pick_find_string() {
             fieldset_delete_char(pick_form);
             break;
         case Q_KEY_ENTER:
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -1195,7 +1193,6 @@ save_form_top:
                 fieldset_insert_char(save_form);
                 break;
             case Q_KEY_ENTER:
-            case C_CR:
                 /*
                  * If the file exists and is a directory, pop up a directory
                  * pick box on it.
@@ -2085,7 +2082,6 @@ struct file_info * view_directory(const char * initial_directory,
                 break;
 
             case Q_KEY_ENTER:
-            case C_CR:
 
                 if (strcmp(file_list[selected_field].name, ".") == 0) {
                     /*
@@ -3374,7 +3370,6 @@ Q_BOOL comm_settings_form(const char * title, Q_BAUD_RATE * baud,
             return Q_FALSE;
 
         case Q_KEY_ENTER:
-        case C_CR:
 
             /*
              * The OK exit point

--- a/source/keyboard.c
+++ b/source/keyboard.c
@@ -666,12 +666,6 @@ static wchar_t * bound_keyboard_keystroke(const int keystroke,
 
     switch (keystroke) {
 
-    case Q_KEY_ENTER:
-        if (net_is_connected() && telnet_is_ascii()) {
-            return L"\015\012";
-        }
-        return L"\015";
-
     case Q_KEY_BACKSPACE:
         return keyboard->kbs;
 

--- a/source/keyboard.c
+++ b/source/keyboard.c
@@ -1170,51 +1170,6 @@ void post_keystroke(const int keystroke, const int flags) {
             }
         }
 
-#ifdef Q_PDCURSES_WIN32
-
-        /*
-         * Windows special case: local shells (cmd.exe) require CRLF.
-         */
-        if ((q_status.online == Q_TRUE) &&
-            ((q_status.dial_method == Q_DIAL_METHOD_SHELL) ||
-             (q_status.dial_method == Q_DIAL_METHOD_COMMANDLINE))
-            ) {
-            if (keystroke == C_CR) {
-                encode_utf8_char(C_LF);
-                qodem_write(q_child_tty_fd, utf8_buffer, strlen(utf8_buffer),
-                            Q_TRUE);
-                if (q_status.emulation == Q_EMUL_DEBUG) {
-                    debug_local_echo(C_LF);
-                    /*
-                     * Force the console to refresh
-                     */
-                    q_screen_dirty = Q_TRUE;
-                }
-            }
-        }
-
-#endif
-
-        /*
-         * VT100-ish special case: when new_line_mode is true, post a LF
-         * after a CR.
-         */
-        if (((q_status.emulation == Q_EMUL_VT100) ||
-             (q_status.emulation == Q_EMUL_VT102) ||
-             (q_status.emulation == Q_EMUL_VT220) ||
-             (q_status.emulation == Q_EMUL_LINUX) ||
-             (q_status.emulation == Q_EMUL_LINUX_UTF8) ||
-             (q_status.emulation == Q_EMUL_XTERM) ||
-             (q_status.emulation == Q_EMUL_XTERM_UTF8)
-            ) && (keystroke == C_CR)
-        ) {
-            if (q_vt100_new_line_mode == Q_TRUE) {
-                encode_utf8_char(C_LF);
-                qodem_write(q_child_tty_fd, utf8_buffer, strlen(utf8_buffer),
-                            Q_TRUE);
-            }
-        }
-
         /*
          * Done
          */
@@ -1388,6 +1343,49 @@ void post_keystroke(const int keystroke, const int flags) {
                 if (q_status.emulation == Q_EMUL_DEBUG) {
                     for (i = 0; i < strlen(utf8_buffer); i++) {
                         debug_local_echo(utf8_buffer[i]);
+                    }
+                }
+
+#ifdef Q_PDCURSES_WIN32
+                /*
+                 * Windows special case: local shells (cmd.exe) require CRLF.
+                 */
+                if ((q_status.online == Q_TRUE) &&
+                    ((q_status.dial_method == Q_DIAL_METHOD_SHELL) ||
+                     (q_status.dial_method == Q_DIAL_METHOD_COMMANDLINE))
+                ) {
+                    if (keystroke == Q_KEY_ENTER) {
+                        encode_utf8_char(C_LF);
+                        qodem_write(q_child_tty_fd, utf8_buffer, strlen(utf8_buffer),
+                                    Q_TRUE);
+                        if (q_status.emulation == Q_EMUL_DEBUG) {
+                            debug_local_echo(C_LF);
+                            /*
+                             * Force the console to refresh
+                             */
+                            q_screen_dirty = Q_TRUE;
+                        }
+                    }
+                }
+#endif
+
+                /*
+                 * VT100-ish special case: when new_line_mode is true, post a LF
+                 * after a CR.
+                 */
+                if (((q_status.emulation == Q_EMUL_VT100) ||
+                     (q_status.emulation == Q_EMUL_VT102) ||
+                     (q_status.emulation == Q_EMUL_VT220) ||
+                     (q_status.emulation == Q_EMUL_LINUX) ||
+                     (q_status.emulation == Q_EMUL_LINUX_UTF8) ||
+                     (q_status.emulation == Q_EMUL_XTERM) ||
+                     (q_status.emulation == Q_EMUL_XTERM_UTF8)
+                    ) && (keystroke == KEY_ENTER)
+                ) {
+                    if (q_vt100_new_line_mode == Q_TRUE) {
+                        encode_utf8_char(C_LF);
+                        qodem_write(q_child_tty_fd, utf8_buffer, strlen(utf8_buffer),
+                                    Q_TRUE);
                     }
                 }
             }

--- a/source/keyboard.c
+++ b/source/keyboard.c
@@ -91,6 +91,7 @@
 #include "ansi.h"
 #include "vt52.h"
 #include "vt100.h"
+#include "atari.h"
 #include "options.h"
 #include "field.h"
 #include "help.h"
@@ -234,6 +235,7 @@ static struct emulation_keyboard terminfo_keyboards[Q_EMULATION_MAX + 1] = {
     {Q_EMUL_LINUX_UTF8, "linux"},
     {Q_EMUL_XTERM, "xterm"},
     {Q_EMUL_XTERM_UTF8, "xterm"},
+    {Q_EMUL_ATARI, "atari"},
     {-1, NULL}
 };
 
@@ -255,6 +257,7 @@ static struct emulation_keyboard emulation_bound_keyboards[Q_EMULATION_MAX +
     {Q_EMUL_LINUX_UTF8, "linux"},
     {Q_EMUL_XTERM, "xterm"},
     {Q_EMUL_XTERM_UTF8, "xterm"},
+    {Q_EMUL_ATARI, "atari"},
     {-1, NULL}
 };
 
@@ -1238,7 +1241,6 @@ void post_keystroke(const int keystroke, const int flags) {
     if ((wcslen(term_string) == 0) ||
         ((wcslen(term_string) == 1) && (term_string[0] == C_CR))
     ) {
-
         /*
          * Send "special" keys through the proper emulator keyboard function
          */
@@ -1266,6 +1268,9 @@ void post_keystroke(const int keystroke, const int flags) {
         case Q_EMUL_XTERM:
         case Q_EMUL_XTERM_UTF8:
             term_string = xterm_keystroke(keystroke, flags);
+            break;
+        case Q_EMUL_ATARI:
+            term_string = atari_keystroke(keystroke);
             break;
         }
     }
@@ -1322,6 +1327,10 @@ void post_keystroke(const int keystroke, const int flags) {
                      * running it through the direct Unicode translation map.
                      */
                     encode_utf8_char(translate_unicode_out(term_string[i]));
+                } else if ((q_status.emulation == Q_EMUL_ATARI)) {
+                    /* Atari control chars need to be sent raw. */
+                    utf8_buffer[0] = term_string[0];
+                    utf8_buffer[1] = 0;
                 } else {
                     /*
                      * Everyone else: try to backmap to the codepage,

--- a/source/modem.c
+++ b/source/modem.c
@@ -1242,7 +1242,7 @@ exit_dialog:
             /*
              * Save if the user said so.
              */
-            if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+            if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                 save_modem_config();
             } else {
                 /*
@@ -1260,7 +1260,6 @@ exit_dialog:
         return;
 
     case Q_KEY_ENTER:
-    case C_CR:
         if (highlighted_row != M_NONE) {
             /*
              * The OK exit point.
@@ -2242,7 +2241,7 @@ Q_BOOL open_serial_port() {
             _("Attention!"), notify_message,
             _(" Y-Proceed Without a Lock File   N-Do Not Open Serial Port "),
             Q_TRUE, 0.0, "YyNn\r"));
-        if ((keystroke == 'y') || (keystroke == C_CR)) {
+        if ((keystroke == 'y') || (keystroke == Q_KEY_ENTER)) {
             memset(lock_filename, 0, sizeof(lock_filename));
         } else {
             return Q_FALSE;
@@ -2330,7 +2329,7 @@ Q_BOOL open_serial_port() {
                 _("Attention!"), notify_message,
                 _(" Y-Proceed Without a Lock File   N-Do Not Open Serial Port "),
                 Q_TRUE, 0.0, "YyNn\r"));
-            if ((keystroke == 'y') || (keystroke == C_CR)) {
+            if ((keystroke == 'y') || (keystroke == Q_KEY_ENTER)) {
                 memset(lock_filename, 0, sizeof(lock_filename));
             } else {
                 return Q_FALSE;

--- a/source/phonebook.c
+++ b/source/phonebook.c
@@ -2720,7 +2720,6 @@ static char * pick_tag_string() {
             fieldset_delete_char(pick_form);
             break;
         case Q_KEY_ENTER:
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -2909,7 +2908,6 @@ static Q_BOOL prompt_ssh_password(const wchar_t * initial_username,
             fieldset_render(pick_form);
             break;
         case Q_KEY_ENTER:
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -3084,7 +3082,6 @@ static char * pick_manual_phone_number() {
             fieldset_delete_char(pick_form);
             break;
         case Q_KEY_ENTER:
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -3237,7 +3234,6 @@ static char * pick_print_destination() {
             fieldset_delete_char(pick_form);
             break;
         case Q_KEY_ENTER:
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -4476,7 +4472,6 @@ static Q_EMULATION pick_emulation() {
             break;
         case Q_KEY_ENTER:
         case Q_KEY_F(10):
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -4671,7 +4666,6 @@ static Q_CODEPAGE pick_codepage(Q_EMULATION emulation) {
             break;
         case Q_KEY_ENTER:
         case Q_KEY_F(10):
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -4802,7 +4796,6 @@ static Q_DIAL_METHOD pick_method() {
             break;
         case Q_KEY_ENTER:
         case Q_KEY_F(10):
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -4943,7 +4936,6 @@ static SORT_METHOD pick_sort() {
             break;
         case Q_KEY_ENTER:
         case Q_KEY_F(10):
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -5228,7 +5220,6 @@ static Q_DOORWAY pick_doorway() {
             break;
         case Q_KEY_ENTER:
         case Q_KEY_F(10):
-        case C_CR:
             /*
              * The OK exit point
              */
@@ -5564,7 +5555,6 @@ static void toggles_form(int * toggles) {
 
         case Q_KEY_ENTER:
         case Q_KEY_F(10):
-        case C_CR:
 
             /*
              * The OK exit point
@@ -6238,7 +6228,6 @@ static void edit_phone_entry_form(struct q_phone_struct * entry) {
             return;
 
         case Q_KEY_ENTER:
-        case C_CR:
             if (field_number == CLEAR_CALL_INFO) {
                 entry->times_on = 0;
                 entry->last_call = 0;
@@ -6641,7 +6630,7 @@ static void edit_phone_entry_form(struct q_phone_struct * entry) {
                             _(" Y-Use the Modem Settings   N-Override the Modem Settings for This Entry "),
                             Q_TRUE, 0.0, "YyNn\r"));
 
-                    if ((keystroke == 'y') || (keystroke == C_CR)) {
+                    if ((keystroke == 'y') || (keystroke == Q_KEY_ENTER)) {
                         use_modem_cfg = Q_TRUE;
                     } else {
                         use_modem_cfg = Q_FALSE;
@@ -6654,7 +6643,7 @@ static void edit_phone_entry_form(struct q_phone_struct * entry) {
                                 _("DTE Baud"), _("Lock DTE Baud? [Y/n] "),
                                 _(" Y-Lock Serial Port Speed   N-Change Serial Port Speed After CONNECT "),
                                 Q_TRUE, 0.0, "YyNn\r"));
-                        if ((keystroke == 'y') || (keystroke == C_CR)) {
+                        if ((keystroke == 'y') || (keystroke == Q_KEY_ENTER)) {
                             lock_dte_baud = Q_TRUE;
                         } else {
                             lock_dte_baud = Q_FALSE;
@@ -6675,7 +6664,7 @@ static void edit_phone_entry_form(struct q_phone_struct * entry) {
                             _(" Y-Use the Default Settings   N-Override the Toggles for This Entry "),
                             Q_TRUE, 0.0, "YyNn\r"));
 
-                    if ((keystroke == 'y') || (keystroke == C_CR)) {
+                    if ((keystroke == 'y') || (keystroke == Q_KEY_ENTER)) {
                         use_default_toggles = Q_TRUE;
                         toggles = 0;
                     } else {
@@ -7590,7 +7579,7 @@ void phonebook_keyboard_handler(const int keystroke, const int flags) {
                             _(" Overwrite File? [Y/n] "),
                             _(" Y-Overwrite Script File   N-Do Not Quicklearn "),
                             Q_TRUE, 0.0, "YyNn\r"));
-                    if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+                    if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                         q_phonebook.selected_entry->quicklearn = Q_TRUE;
                         q_phonebook.selected_entry->tagged = Q_TRUE;
                         q_phonebook.tagged++;
@@ -7902,7 +7891,6 @@ void phonebook_keyboard_handler(const int keystroke, const int flags) {
         break;
 
     case Q_KEY_ENTER:
-    case C_CR:
         /*
          * Dial
          */

--- a/source/states.c
+++ b/source/states.c
@@ -68,6 +68,9 @@ void keyboard_handler() {
         return;
     }
 
+    if (keystroke == C_CR)
+        keystroke = Q_KEY_ENTER;
+
     switch (q_program_state) {
 
     case Q_STATE_CONSOLE:
@@ -409,7 +412,7 @@ Q_PROGRAM_STATE original_state;
  */
 void screensaver_keyboard_handler(const int keystroke, const int flags) {
 
-    if ((keystroke == Q_KEY_ENTER) || (keystroke == C_CR)) {
+    if ((keystroke == Q_KEY_ENTER)) {
         if (password_buffer_n > 0) {
             if (strcmp(password_buffer,
                        get_option(Q_OPTION_SCREENSAVER_PASSWORD)) == 0) {

--- a/source/states.c
+++ b/source/states.c
@@ -70,6 +70,8 @@ void keyboard_handler() {
 
     if (keystroke == C_CR)
         keystroke = Q_KEY_ENTER;
+    if (keystroke == C_BS)
+        keystroke == Q_KEY_BACKSPACE;
 
     switch (q_program_state) {
 

--- a/source/translate.c
+++ b/source/translate.c
@@ -1468,7 +1468,7 @@ void translate_table_editor_8bit_keyboard_handler(const int keystroke,
                 /*
                  * Save if the user said so
                  */
-                if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+                if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                     if (editing_table == INPUT_8BIT) {
                         copy_table_8bit(&editing_table_8bit,
                             &table_8bit_input);
@@ -1569,7 +1569,6 @@ void translate_table_editor_8bit_keyboard_handler(const int keystroke,
         return;
 
     case Q_KEY_ENTER:
-    case C_CR:
         if (editing_entry == Q_FALSE) {
             /*
              * ENTER - Begin editing
@@ -2023,7 +2022,7 @@ void translate_table_editor_unicode_keyboard_handler(const int keystroke,
                 /*
                  * Save if the user said so
                  */
-                if ((new_keystroke == 'y') || (new_keystroke == C_CR)) {
+                if ((new_keystroke == 'y') || (new_keystroke == Q_KEY_ENTER)) {
                     if (editing_table == INPUT_UNICODE) {
                         copy_table_unicode(&editing_table_unicode,
                             &table_unicode_input);
@@ -2147,7 +2146,6 @@ void translate_table_editor_unicode_keyboard_handler(const int keystroke,
         return;
 
     case Q_KEY_ENTER:
-    case C_CR:
         if (editing_entry == Q_FALSE) {
             /*
              * ENTER - Begin editing


### PR DESCRIPTION
Just for the hell of it. :)

I've also unified the handling of the enter key / CR, and made the code use Q_KEY_BACKSPACE for backspace, since the emulations will/should handle it anyhow. This is needed for character sets that use a control code for CR/BS different from ASCII.

I didn't test the tab-stop code, which I pilfered it from the vt100 code; but I was able to connect to an ATASCII BBS, navigate around ,etc. without issue.